### PR TITLE
Add convenience function `phasefunction`

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "RadiativeTransfer"
 uuid = "ace8185b-fa20-42f5-912d-1e850dbe6a09"
 authors = ["Rupesh Jeyaram <rjeyaram@caltech.edu> and contributors"]
-version = "0.2.2"
+version = "0.3.1"
 
 [deps]
 BenchmarkTools = "6e4b80f9-dd63-53aa-95a3-0cdb28fa8baf"

--- a/docs/src/pages/Scattering.md
+++ b/docs/src/pages/Scattering.md
@@ -10,6 +10,8 @@ You can calculate a phase function in three steps:
 2. Use [`make_mie_model`](@ref) to set up all calculation parameters
 3. Use [`compute_aerosol_optical_properties`](@ref) to perform the phase-function calculation using the defined model settings
 
+Equivalently, you can skip steps 2 and 3 and directly use the function [`phasefunction`](@ref) with your aerosol.
+
 ## Example
 
 ```julia
@@ -99,6 +101,11 @@ make_mie_model
 
 ```@docs
 compute_aerosol_optical_properties
+```
+
+## Phase function
+```@docs
+phasefunction
 ```
 
 ## Types

--- a/src/Scattering/Mie/mie_helper_functions.jl
+++ b/src/Scattering/Mie/mie_helper_functions.jl
@@ -423,3 +423,52 @@ function compute_Z_moments(mod::AbstractPolarizationType, μ, greek_coefs::Greek
     # Return Z-moments
     return arr_type(𝐙⁺⁺), arr_type(𝐙⁻⁺)
 end
+
+"""
+    phasefunction(aerosol, λ; kwargs...) -> μ, f
+Convenience function that given an `aerosol` (output of [`make_univariate_aerosol`](@ref),
+and a wavelength of incoming photon `λ`, it computes the phase function `f` (for the intensity).
+`μ` is the cosine of the angle, so `θ = acos.(μ)`.
+
+`f` is normalized such that 
+```math
+\frac{1}{4\pi}\int_0^{2\pi}d\phi \int_{-1}^1 p(\mu) d\mu  = 1
+```
+
+## Keywords
+```
+polarization_type = Stokes_IQUV()   # Polarization type
+l_max = 20 # Trunction length for legendre terms
+Δ_angle = 2 # Exclusion angle for forward peak (in fitting procedure)
+truncation_type = δBGE(20, 2)
+```
+## Notes
+The phase function returned is
+In general, A phase function represents the spatial distribution of light scattered by a particle.
+It does not have any effect on the amount of light actually scattered by the particle (that quantity
+is determined by the scattering cross section of the particle). As a result, the phase function is
+a normalized distribution, i.e., the integral of the phase function over all scattering angles is 1.
+Truncation is applied to highly forward-peaked phase functions in order to reduce the polynomial
+order required to represent its anisotropy. This is done by assuming that a fraction f of the light
+scattered in the forward direction is light that has not interacted with the particle at all.
+As a result, this fraction no longer contributes to the integral of the phase function over all angles.
+In order to normalize the truncated phase function we divide it by (1-f). Of course,
+this extra factor has to be balanced by a corresponding term in the numerator of the corresponding
+radiative transfer equation. This is done by absorbing the numerator into a modified form for the
+optical thickness and the single scattering albedo of the scattering particle.
+
+See Sanghavi and Stephens (2015) for further details.
+"""
+function phasefunction(aerosol, λ;
+        polarization_type = Stokes_IQUV()   # Polarization type
+        l_max = 20 # Trunction length for legendre terms
+        Δ_angle = 2 # Exclusion angle for forward peak (in fitting procedure)
+        truncation_type = δBGE(20, 2)
+    )
+        aerosol_optics_NAI2 = compute_aerosol_optical_properties(model_NAI2);
+    μ, w_μ = gausslegendre(2000)
+    f₁₁, f₁₂, f₂₂, f₃₃, f₃₄, f₄₄ = Scattering.reconstruct_phase(aerosol_optics_NAI2.greek_coefs, μ);
+    f = w_μ .* f₁₁
+    return μ, f
+end
+

--- a/src/Scattering/Mie/mie_helper_functions.jl
+++ b/src/Scattering/Mie/mie_helper_functions.jl
@@ -437,10 +437,12 @@ and a wavelength of incoming photon `λ`, it computes the phase function `f` (fo
 
 ## Keywords
 ```
-polarization_type = Stokes_IQUV()   # Polarization type
-l_max = 20 # Trunction length for legendre terms
-Δ_angle = 2 # Exclusion angle for forward peak (in fitting procedure)
-truncation_type = δBGE(20, 2)
+polarization_type = Stokes_IQUV(),   # Polarization type
+l_max = 20, # Trunction length for legendre terms
+Δ_angle = 2, # Exclusion angle for forward peak (in fitting procedure)
+truncation_type = δBGE(20, 2),
+miemethod = NAI2(), # for make_mie_model
+N = 2000, # how many angles in [-π/2, π/2) to calculate over
 ```
 ## Notes
 The phase function returned is
@@ -460,13 +462,16 @@ optical thickness and the single scattering albedo of the scattering particle.
 See Sanghavi and Stephens (2015) for further details.
 """
 function phasefunction(aerosol, λ;
-        polarization_type = Stokes_IQUV()   # Polarization type
-        l_max = 20 # Trunction length for legendre terms
-        Δ_angle = 2 # Exclusion angle for forward peak (in fitting procedure)
-        truncation_type = δBGE(20, 2)
+        polarization_type = Stokes_IQUV(),   # Polarization type
+        l_max = 20, # Trunction length for legendre terms
+        Δ_angle = 2, # Exclusion angle for forward peak (in fitting procedure)
+        truncation_type = δBGE(20, 2),
+        miemethod = NAI2(), # for make_mie_model
+        N = 2000, # how many angles in [-π/2, π/2) to calculate over
     )
-        aerosol_optics_NAI2 = compute_aerosol_optical_properties(model_NAI2);
-    μ, w_μ = gausslegendre(2000)
+    model_NAI2 = make_mie_model(miemethod, aerosol, λ, polarization_type, truncation_type);
+    aerosol_optics_NAI2 = compute_aerosol_optical_properties(model_NAI2);
+    μ, w_μ = gausslegendre(N)
     f₁₁, f₁₂, f₂₂, f₃₃, f₃₄, f₄₄ = Scattering.reconstruct_phase(aerosol_optics_NAI2.greek_coefs, μ);
     f = w_μ .* f₁₁
     return μ, f

--- a/src/Scattering/Scattering.jl
+++ b/src/Scattering/Scattering.jl
@@ -40,6 +40,7 @@ export compute_B, compute_ab, GreekCoefs, comp_ab, compute_mie_π_τ!,
        compute_ref_aerosol_extinction,
        ConjugateTransposePairs, AbstractPolarizationType, 
        AbstractAerosolType, AbstractAerosolType, MieModel, 
-       AbstractTruncationType
+       AbstractTruncationType,
+       phasefunction
 
 end


### PR DESCRIPTION
So that users don't have to explicitly add FastGaussQuadrature to their Project.toml, and also so that they don't care to make all these uncessary intermediate steps.

Closes #85 